### PR TITLE
update to php 8

### DIFF
--- a/src/Cli/Cli.php
+++ b/src/Cli/Cli.php
@@ -67,7 +67,7 @@ if (!function_exists(__NAMESPACE__.'usage')) {
                     : $a->name()
             );
         }
-        $arguments = trim(implode($arguments, ' '));
+        $arguments = trim(implode(' ', $arguments));
 
         return sprintf(
             'Usage: %s [OPTIONS]... %s%s',


### PR DESCRIPTION
implode now only accepts separator as first argument